### PR TITLE
Add item property to MenuUIParams in JQueryUI

### DIFF
--- a/jqueryui/jqueryui.d.ts
+++ b/jqueryui/jqueryui.d.ts
@@ -507,6 +507,7 @@ declare module JQueryUI {
     }
 
     interface MenuUIParams {
+        item?: JQuery;
     }
 
     interface MenuEvent {


### PR DESCRIPTION
The ui parameter that is returned to the caller in jQueryUI menu events (e.g. select) has an optional property named item, but it was not included in this type file.